### PR TITLE
Make more compatible with Python 3 + Black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
 
 before_install:
     - bash .travis_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - 3.7
 
 before_install:
     - bash .travis_dependencies.sh

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -11,7 +11,7 @@ conda_create ()
     conda update -q conda
     conda config --add channels pypi
     conda info -a
-    deps='six nose coverage pip numpy scipy pandas matplotlib'
+    deps='six nose coverage pip numpy scipy pandas matplotlib future'
 
     conda create -q -n $ENV_NAME "python=$TRAVIS_PYTHON_VERSION" $deps
 }

--- a/app/entrofy.py
+++ b/app/entrofy.py
@@ -113,7 +113,7 @@ def entrofy(
         Optionally, you may pre-specify a set of rows to be forced into the solution.
 
     quantile : float, values in [0,1]
-        Define the quantile to be used in tie-breaking between top choices at 
+        Define the quantile to be used in tie-breaking between top choices at
         every step; choose e.g. 0.01 for the top 1% quantile
         By default, 0.01
 

--- a/app/entrofy.py
+++ b/app/entrofy.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from __future__ import division
 
+from builtins import zip
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import pandas as pd
 
@@ -62,7 +66,7 @@ def __entrofy(X, k, w=None, q=None, pre_selects=None, quantile=0.01):
         p[np.isnan(p)] = 0.0
 
         # Compute the candidate distributions
-        p_new = (p * i + X) / (i + 1.0)
+        p_new = old_div((p * i + X), (i + 1.0))
 
         # Wherever X is nan, propagate the old p since we have no new information
         p_new[Xn] = (Xn * p)[Xn]

--- a/app/entrofy.py
+++ b/app/entrofy.py
@@ -4,22 +4,24 @@ from __future__ import print_function
 import numpy as np
 import pandas as pd
 
+
 def obj(p, w, q):
     # Prevent numerical underflow in log
 
     amin = 1e-200
 
-    pbar = 1. - p
-    qbar = 1. - q
+    pbar = 1.0 - p
+    qbar = 1.0 - q
 
-    entropy = (p * (np.log(p + amin) - np.log(q + amin)) +
-               pbar * (np.log(pbar + amin) - np.log(qbar + amin)))
+    entropy = p * (np.log(p + amin) - np.log(q + amin)) + pbar * (
+        np.log(pbar + amin) - np.log(qbar + amin)
+    )
 
-    return - entropy.dot(w)
+    return -entropy.dot(w)
 
 
 def __entrofy(X, k, w=None, q=None, pre_selects=None, quantile=0.01):
-    '''See entrofy() for documentation'''
+    """See entrofy() for documentation"""
 
     n_participants, n_attributes = X.shape
 
@@ -73,7 +75,7 @@ def __entrofy(X, k, w=None, q=None, pre_selects=None, quantile=0.01):
 
         # Select the top score.  Break near-ties randomly.
         delta_real = delta[np.isfinite(delta)]
-        target_score = np.percentile(delta_real, 1.0-quantile)
+        target_score = np.percentile(delta_real, 1.0 - quantile)
 
         new_idx = np.random.choice(np.flatnonzero(delta >= target_score))
         y[new_idx] = True
@@ -81,8 +83,10 @@ def __entrofy(X, k, w=None, q=None, pre_selects=None, quantile=0.01):
     return obj(np.nanmean(X[y], axis=0), w, q), np.flatnonzero(y)
 
 
-def entrofy(X, k, w=None, q=None, pre_selects=None, quantile=0.01, n_samples=15):
-    '''Entrofy your panel.
+def entrofy(
+    X, k, w=None, q=None, pre_selects=None, quantile=0.01, n_samples=15
+):
+    """Entrofy your panel.
 
     Parameters
     ----------
@@ -122,13 +126,14 @@ def entrofy(X, k, w=None, q=None, pre_selects=None, quantile=0.01, n_samples=15)
     idx : np.ndarray, shape=(k,)
         Indicies of the selected rows
 
-    '''
+    """
     if pre_selects is not None and len(pre_selects):
         n_samples = 1
 
-    results = [__entrofy(X, k, w=w, q=q, pre_selects=pre_selects,
-                         quantile=quantile)
-               for _ in range(n_samples)]
+    results = [
+        __entrofy(X, k, w=w, q=q, pre_selects=pre_selects, quantile=quantile)
+        for _ in range(n_samples)
+    ]
 
     max_score, best = results[0]
     for score, solution in results[1:]:
@@ -165,13 +170,13 @@ def binarize(df, n_bins=5):
                 continue
 
             z += 1.0
-            new_name = '{}_{}'.format(column, value)
+            new_name = "{}_{}".format(column, value)
             df2[new_name] = new_series
             df2[new_name][pd.isnull(data)] = np.nan
             groupkeys.append(new_name)
 
         for k in groupkeys:
-            targets[k] = 1./z
+            targets[k] = 1.0 / z
 
     return df2, targets
 
@@ -189,24 +194,29 @@ def process_csv(fdesc):
     headers = []
     headers.extend([dict(title=_) for _ in df.columns])
 
-    return df.to_json(orient='values'), headers, targets, len(df), p_all
+    return df.to_json(orient="values"), headers, targets, len(df), p_all
 
 
 def process_table(data, index, columns, k, q, w, pre_selects):
 
-    df = pd.DataFrame(data=data, columns=[_['title'] for _ in columns])
+    df = pd.DataFrame(data=data, columns=[_["title"] for _ in columns])
     # Find the index column
     df = df.set_index(index)
 
     X = df.values.astype(np.float)
-    score, rows = entrofy(X, k, q=np.asarray([float(_) for _ in q]),
-                                w=np.asarray([float(_) for _ in w]),
-                                pre_selects=pre_selects)
+    score, rows = entrofy(
+        X,
+        k,
+        q=np.asarray([float(_) for _ in q]),
+        w=np.asarray([float(_) for _ in w]),
+        pre_selects=pre_selects,
+    )
 
     p_all = compute_p(X)
     p_selected = compute_p(X[rows])
 
     return score, rows, p_all, p_selected
+
 
 def compute_p(X):
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.7
 pandas>=0.15
 flask
 configparser
+future

--- a/app/server.py
+++ b/app/server.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 from future import standard_library
+
 standard_library.install_aliases()
 import argparse
 from flask import Flask, request, redirect, url_for, render_template, Response
@@ -20,6 +21,7 @@ DEBUG = True
 app = Flask(__name__)
 app.config.from_object(__name__)
 
+
 def load_config(server_ini):
     P = configparser.RawConfigParser()
 
@@ -30,7 +32,7 @@ def load_config(server_ini):
     for section in P.sections():
         CFG[section] = dict(P.items(section))
 
-    for (k, v) in CFG['server'].items():
+    for (k, v) in CFG["server"].items():
         app.config[k] = v
     return CFG
 
@@ -39,86 +41,100 @@ def run(**kwargs):
     app.run(**kwargs)
 
 
-@app.route('/h', methods=['POST'])
+@app.route("/h", methods=["POST"])
 def sample():
 
     data = request.get_json()
-    pre_selects = data['pre_selects']
+    pre_selects = data["pre_selects"]
     if len(pre_selects) == 0:
         pre_selects = None
-    score, rows, p_all, p_selected = entrofy.process_table(data['data'],
-                                 data['index'],
-                                 data['columns'],
-                                 int(data['n_select']),
-                                 data['target'],
-                                 data['weights'],
-                                 pre_selects)
+    score, rows, p_all, p_selected = entrofy.process_table(
+        data["data"],
+        data["index"],
+        data["columns"],
+        int(data["n_select"]),
+        data["target"],
+        data["weights"],
+        pre_selects,
+    )
 
-    return json.dumps(dict(selections=list(rows),
-                            p_all=list(p_all),
-                            p_selected=list(p_selected)))
+    return json.dumps(
+        dict(
+            selections=list(rows),
+            p_all=list(p_all),
+            p_selected=list(p_selected),
+        )
+    )
 
 
-@app.route('/p', methods=['POST'])
+@app.route("/p", methods=["POST"])
 def process():
 
-    fdesc = request.files['csv']
+    fdesc = request.files["csv"]
 
     table, columns, targets, n, raw_stats = entrofy.process_csv(fdesc)
 
-    return render_template('process.html',
-                           table=table,
-                           columns=json.dumps(columns),
-                           kmax=n,
-                           targets=json.dumps(targets),
-                           raw_stats=json.dumps(raw_stats))
+    return render_template(
+        "process.html",
+        table=table,
+        columns=json.dumps(columns),
+        kmax=n,
+        targets=json.dumps(targets),
+        raw_stats=json.dumps(raw_stats),
+    )
 
 
-@app.route('/')
+@app.route("/")
 def index():
-    '''Top-level web page'''
-    return render_template('index.html')
+    """Top-level web page"""
+    return render_template("index.html")
 
 
 # Main block
 def process_arguments(args):
 
-    parser = argparse.ArgumentParser(description='entrofy web server')
+    parser = argparse.ArgumentParser(description="entrofy web server")
 
-    parser.add_argument('-i',
-                        '--ini',
-                        dest='ini',
-                        required=False,
-                        type=str,
-                        default='server.ini',
-                        help='Path to server.ini file')
+    parser.add_argument(
+        "-i",
+        "--ini",
+        dest="ini",
+        required=False,
+        type=str,
+        default="server.ini",
+        help="Path to server.ini file",
+    )
 
-    parser.add_argument('-p',
-                        '--port',
-                        dest='port',
-                        required=False,
-                        type=int,
-                        default=5000,
-                        help='Port')
+    parser.add_argument(
+        "-p",
+        "--port",
+        dest="port",
+        required=False,
+        type=int,
+        default=5000,
+        help="Port",
+    )
 
-    parser.add_argument('--host',
-                        dest='host',
-                        required=False,
-                        type=str,
-                        default='0.0.0.0',
-                        help='host')
+    parser.add_argument(
+        "--host",
+        dest="host",
+        required=False,
+        type=str,
+        default="0.0.0.0",
+        help="host",
+    )
 
     return vars(parser.parse_args(args))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parameters = process_arguments(sys.argv[1:])
 
-    CFG = load_config(parameters['ini'])
+    CFG = load_config(parameters["ini"])
 
-    port = parameters['port']
+    port = parameters["port"]
 
-    if os.environ.get('ENV') == 'production':
-        port = int(os.environ.get('PORT'))
+    if os.environ.get("ENV") == "production":
+        port = int(os.environ.get("PORT"))
 
-    run(host=parameters['host'], port=port, debug=DEBUG, processes=3)
+    run(host=parameters["host"], port=port, debug=DEBUG, processes=3)

--- a/app/server.py
+++ b/app/server.py
@@ -2,10 +2,12 @@
 
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import argparse
 from flask import Flask, request, redirect, url_for, render_template, Response
 from werkzeug import secure_filename
-import ConfigParser
+import configparser
 import os
 import re
 import sys
@@ -19,7 +21,7 @@ app = Flask(__name__)
 app.config.from_object(__name__)
 
 def load_config(server_ini):
-    P = ConfigParser.RawConfigParser()
+    P = configparser.RawConfigParser()
 
     P.opionxform = str
     P.read(server_ini)
@@ -28,7 +30,7 @@ def load_config(server_ini):
     for section in P.sections():
         CFG[section] = dict(P.items(section))
 
-    for (k, v) in CFG['server'].iteritems():
+    for (k, v) in CFG['server'].items():
         app.config[k] = v
     return CFG
 

--- a/entrofy/__init__.py
+++ b/entrofy/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''Entrofy'''
+"""Entrofy"""
 
 from . import mappers
 from . import plotting

--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 '''Entrofy core optimization routines'''
 
+from builtins import range
 import warnings
 from six.moves import cPickle as pickle
 

--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -33,11 +33,15 @@ def _check_probabilities(mapper):
 
     for p in six.itervalues(mapper.targets):
         if p < 0:
-            raise RuntimeError("{} target probability {} < 0".format(mapper, p))
+            raise RuntimeError(
+                "{} target probability {} < 0".format(mapper, p)
+            )
         score += p
 
     if score > 1:
-        raise RuntimeError("{} total target probability {} > 0".format(mapper, score))
+        raise RuntimeError(
+            "{} total target probability {} > 0".format(mapper, score)
+        )
 
 
 def construct_mappers(dataframe, weights, datatypes=None):
@@ -155,15 +159,21 @@ def entrofy(
 
     # Validate n_trials
     if n_trials <= 0 or n_trials != int(n_trials):
-        raise ValueError("n_trials={} must be a positive integer".format(n_trials))
+        raise ValueError(
+            "n_trials={} must be a positive integer".format(n_trials)
+        )
 
     # Validate quantiles
     if not 0 <= quantile <= 1.0 or not isinstance(quantile, float):
-        raise ValueError("quantile={:.2f} must be in the range [0, 1]".format(quantile))
+        raise ValueError(
+            "quantile={:.2f} must be in the range [0, 1]".format(quantile)
+        )
 
     # Validate alpha
     if not 0 < alpha <= 1.0 or not isinstance(alpha, float):
-        raise ValueError("alpha={:.2f} must be in the range (0, 1]".format(alpha))
+        raise ValueError(
+            "alpha={:.2f} must be in the range (0, 1]".format(alpha)
+        )
 
     # Drop the opt-outs
     if opt_outs is not None:
@@ -191,7 +201,10 @@ def entrofy(
         df_binary = df_binary.join(new_df)
         all_weights.update({k: weights[key] for k in new_df.columns})
         all_probabilities.update(
-            {"{}{}".format(mapper.prefix, k): mapper.targets[k] for k in mapper.targets}
+            {
+                "{}{}".format(mapper.prefix, k): mapper.targets[k]
+                for k in mapper.targets
+            }
         )
 
     # Construct the target probability vector and weight vector
@@ -232,7 +245,9 @@ def entrofy(
     return dataframe.index[best], max_score
 
 
-def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=0.5):
+def __entrofy(
+    X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=0.5
+):
     """See entrofy() for documentation"""
 
     n_participants, n_attributes = X.shape
@@ -303,7 +318,10 @@ def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=
         new_idx = rng.choice(np.flatnonzero(delta >= target_score))
         y[new_idx] = True
 
-    return __objective(np.nansum(X[y], axis=0), w, q, alpha=alpha), np.flatnonzero(y)
+    return (
+        __objective(np.nansum(X[y], axis=0), w, q, alpha=alpha),
+        np.flatnonzero(y),
+    )
 
 
 def __objective(p, w, q, alpha=0.5):

--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
-'''Entrofy core optimization routines'''
+"""Entrofy core optimization routines"""
 
 from builtins import range
 import warnings
@@ -13,10 +13,11 @@ import six
 from .mappers import ContinuousMapper, ObjectMapper
 from .utils import check_random_state
 
-__all__ = ['entrofy', 'construct_mappers', 'save', 'load']
+__all__ = ["entrofy", "construct_mappers", "save", "load"]
+
 
 def _check_probabilities(mapper):
-    '''Verify that the target probabilities for a mapper sum to at most 1.
+    """Verify that the target probabilities for a mapper sum to at most 1.
 
     Parameters
     ----------
@@ -26,21 +27,21 @@ def _check_probabilities(mapper):
     ------
     RuntimeError
         if target probabilities are ill-formed
-    '''
+    """
 
     score = 0.0
 
     for p in six.itervalues(mapper.targets):
         if p < 0:
-            raise RuntimeError('{} target probability {} < 0'.format(mapper, p))
+            raise RuntimeError("{} target probability {} < 0".format(mapper, p))
         score += p
 
     if score > 1:
-        raise RuntimeError('{} total target probability {} > 0'.format(mapper, score))
+        raise RuntimeError("{} total target probability {} > 0".format(mapper, score))
 
 
 def construct_mappers(dataframe, weights, datatypes=None):
-    '''Construct mappers from a dataframe
+    """Construct mappers from a dataframe
 
     Parameters
     ----------
@@ -59,7 +60,7 @@ def construct_mappers(dataframe, weights, datatypes=None):
     -------
     mappers : dict
         `mappers[key]` is a `Mapper` object for column `dataframe[key]`.
-    '''
+    """
     mappers = {}
 
     # Populate any missing mappres
@@ -86,9 +87,19 @@ def construct_mappers(dataframe, weights, datatypes=None):
     return mappers
 
 
-def entrofy(dataframe, n, mappers=None, weights=None, pre_selects=None,
-            opt_outs=None, quantile=0.01, n_trials=15, seed=None, alpha=0.5):
-    '''Entrofy your panel.
+def entrofy(
+    dataframe,
+    n,
+    mappers=None,
+    weights=None,
+    pre_selects=None,
+    opt_outs=None,
+    quantile=0.01,
+    n_trials=15,
+    seed=None,
+    alpha=0.5,
+):
+    """Entrofy your panel.
 
     Parameters
     ----------
@@ -138,22 +149,21 @@ def entrofy(dataframe, n, mappers=None, weights=None, pre_selects=None,
     score : float
         The score of the solution found.  Larger is better.
 
-    '''
+    """
 
     rng = check_random_state(seed)
 
-
     # Validate n_trials
     if n_trials <= 0 or n_trials != int(n_trials):
-        raise ValueError('n_trials={} must be a positive integer'.format(n_trials))
+        raise ValueError("n_trials={} must be a positive integer".format(n_trials))
 
     # Validate quantiles
     if not 0 <= quantile <= 1.0 or not isinstance(quantile, float):
-        raise ValueError('quantile={:.2f} must be in the range [0, 1]'.format(quantile))
+        raise ValueError("quantile={:.2f} must be in the range [0, 1]".format(quantile))
 
     # Validate alpha
     if not 0 < alpha <= 1.0 or not isinstance(alpha, float):
-        raise ValueError('alpha={:.2f} must be in the range (0, 1]'.format(alpha))
+        raise ValueError("alpha={:.2f} must be in the range (0, 1]".format(alpha))
 
     # Drop the opt-outs
     if opt_outs is not None:
@@ -180,7 +190,9 @@ def entrofy(dataframe, n, mappers=None, weights=None, pre_selects=None,
         new_df = mapper.transform(dataframe[key])
         df_binary = df_binary.join(new_df)
         all_weights.update({k: weights[key] for k in new_df.columns})
-        all_probabilities.update({'{}{}'.format(mapper.prefix, k):mapper.targets[k] for k in mapper.targets})
+        all_probabilities.update(
+            {"{}{}".format(mapper.prefix, k): mapper.targets[k] for k in mapper.targets}
+        )
 
     # Construct the target probability vector and weight vector
     target_prob = np.empty(len(df_binary.columns))
@@ -196,13 +208,19 @@ def entrofy(dataframe, n, mappers=None, weights=None, pre_selects=None,
         pre_selects_i = [df_binary.index.get_loc(_) for _ in pre_selects]
 
     # Run the specified number of randomized trials
-    results = [__entrofy(df_binary.values.astype(float), n, rng,
-                         w=target_weight,
-                         q=target_prob,
-                         pre_selects=pre_selects_i,
-                         quantile=quantile,
-                         alpha=alpha)
-               for _ in range(n_trials)]
+    results = [
+        __entrofy(
+            df_binary.values.astype(float),
+            n,
+            rng,
+            w=target_weight,
+            q=target_prob,
+            pre_selects=pre_selects_i,
+            quantile=quantile,
+            alpha=alpha,
+        )
+        for _ in range(n_trials)
+    ]
 
     # Select the trial with the best score
     max_score, best = results[0]
@@ -215,7 +233,7 @@ def entrofy(dataframe, n, mappers=None, weights=None, pre_selects=None,
 
 
 def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=0.5):
-    '''See entrofy() for documentation'''
+    """See entrofy() for documentation"""
 
     n_participants, n_attributes = X.shape
     X = np.array(X, dtype=np.float)
@@ -271,14 +289,16 @@ def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=
         p_new[Xn] = (Xn * p)[Xn]
 
         # Compute marginal gain for each candidate
-        delta = __objective(p_new, w, q, alpha=alpha) - __objective(p, w, q, alpha=alpha)
+        delta = __objective(p_new, w, q, alpha=alpha) - __objective(
+            p, w, q, alpha=alpha
+        )
 
         # Knock out the points we've already taken
         delta[y] = -np.inf
 
         # Select the top score.  Break near-ties randomly.
         delta_real = delta[np.isfinite(delta)]
-        target_score = np.percentile(delta_real, 100 * (1.0-quantile))
+        target_score = np.percentile(delta_real, 100 * (1.0 - quantile))
 
         new_idx = rng.choice(np.flatnonzero(delta >= target_score))
         y[new_idx] = True
@@ -287,13 +307,23 @@ def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=
 
 
 def __objective(p, w, q, alpha=0.5):
-    '''Compute the objective value of a solution.'''
-    return ((np.minimum(q, p))**(alpha)).dot(w)
+    """Compute the objective value of a solution."""
+    return ((np.minimum(q, p)) ** (alpha)).dot(w)
 
 
-def save(idx, filename, dataframe=None, mappers=None, weights=None,
-         pre_selects=None, opt_outs=None, quantile=1e-2, n_trials=15,
-         seed=None, alpha=0.5):
+def save(
+    idx,
+    filename,
+    dataframe=None,
+    mappers=None,
+    weights=None,
+    pre_selects=None,
+    opt_outs=None,
+    quantile=1e-2,
+    n_trials=15,
+    seed=None,
+    alpha=0.5,
+):
     """
     Save an Entrofy run to disk.
     The data will be saved in a pickle file containing a dictionary with
@@ -358,12 +388,19 @@ def save(idx, filename, dataframe=None, mappers=None, weights=None,
         else:
             raise TypeError("Type of mapper not recognized!")
 
-
-    state = {"index": idx, "targets": targets, "data_types":data_types,
-             "boundaries": boundaries, "weights": weights,
-             "pre_selects": pre_selects, "opt_outs": opt_outs,
-             "quantile":quantile, "n_trials":n_trials, "seed": seed,
-             "alpha": alpha}
+    state = {
+        "index": idx,
+        "targets": targets,
+        "data_types": data_types,
+        "boundaries": boundaries,
+        "weights": weights,
+        "pre_selects": pre_selects,
+        "opt_outs": opt_outs,
+        "quantile": quantile,
+        "n_trials": n_trials,
+        "seed": seed,
+        "alpha": alpha,
+    }
 
     if dataframe is not None:
         state["dataframe"] = dataframe
@@ -410,15 +447,18 @@ def load(filename, dataframe=None):
         n_out = len(list(targets[key].keys()))
         if data_types[key] == "continuous":
             column_names = list(targets[key].keys())
-            mappers[key] = ContinuousMapper(dataframe[key], n_out=n_out,
-                                            boundaries=boundaries[key],
-                                            targets=targets[key],
-                                            column_names=column_names)
+            mappers[key] = ContinuousMapper(
+                dataframe[key],
+                n_out=n_out,
+                boundaries=boundaries[key],
+                targets=targets[key],
+                column_names=column_names,
+            )
 
         elif data_types[key] == "categorical":
-            mappers[key] = ObjectMapper(dataframe[key], n_out=n_out,
-                                        targets=targets[key])
-
+            mappers[key] = ObjectMapper(
+                dataframe[key], n_out=n_out, targets=targets[key]
+            )
 
     state["mappers"] = mappers
 

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -2,6 +2,9 @@
 # -*- encoding: utf-8 -*-
 '''Column mapper object definitions'''
 
+from builtins import zip
+from builtins import range
+from builtins import object
 import numpy as np
 import pandas as pd
 import six 

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -83,15 +83,19 @@ class BaseMapper(object):
             A DataFrame with the same index as `column`, and one binary-valued
             column for each potential output.
         """
-        new_columns = sorted(["{}{}".format(self.prefix, key) for key in self.targets])
-        df = pd.DataFrame(index=column.index, columns=new_columns, dtype=np.float)
+        new_columns = sorted(
+            ["{}{}".format(self.prefix, key) for key in self.targets]
+        )
+        df = pd.DataFrame(
+            index=column.index, columns=new_columns, dtype=np.float
+        )
 
         nonnulls = ~column.isnull()
 
         for key in self._map:
-            df.loc[nonnulls, "{}{}".format(self.prefix, key)] = column[nonnulls].apply(
-                self._map[key]
-            )
+            df.loc[nonnulls, "{}{}".format(self.prefix, key)] = column[
+                nonnulls
+            ].apply(self._map[key])
             df.loc[~nonnulls, "{}{}".format(self.prefix, key)] = None
 
         return df
@@ -216,7 +220,9 @@ class ContinuousMapper(BaseMapper):
             # if the boundaries are given, just use these
             self.boundaries = boundaries
             assert self.n_out == len(boundaries) - 1, (
-                "The boundaries must " "equal the number of " "columns plus one."
+                "The boundaries must "
+                "equal the number of "
+                "columns plus one."
             )
         else:
             self.boundaries = np.linspace(minval, maxval, n_out + 1)
@@ -231,7 +237,9 @@ class ContinuousMapper(BaseMapper):
         if targets is not None:
             assert [
                 c == t
-                for c, t in zip(np.sort(column_names), np.sort(list(targets.keys())))
+                for c, t in zip(
+                    np.sort(column_names), np.sort(list(targets.keys()))
+                )
             ]
 
         # empty target dictionary
@@ -245,7 +253,9 @@ class ContinuousMapper(BaseMapper):
                 cname = (
                     self.prefix
                     + self.prefix
-                    + "{:2f}_{:2f}".format(self.boundaries[0], self.boundaries[1])
+                    + "{:2f}_{:2f}".format(
+                        self.boundaries[0], self.boundaries[1]
+                    )
                 )
             else:
                 cname = column_names[0]

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import zip
+from builtins import range
 import matplotlib.pyplot as plt
 import matplotlib
 
@@ -230,7 +232,7 @@ def _plot_categorical(df, xlabel, ylabel, x_keys, y_keys, prefac, ax, cmap, s):
             counts.append(len(df[(df[xlabel] == x_keys[i]) &
                                  (df[ylabel] == y_keys[j])]))
 
-    x, y = zip(*tuples)
+    x, y = list(zip(*tuples))
 
     cmap = plt.cm.get_cmap(cmap)
     sizes = (np.array(counts)/np.sum(counts))

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -2,7 +2,6 @@ from __future__ import division
 from builtins import zip
 from builtins import range
 import matplotlib.pyplot as plt
-import matplotlib
 
 import numpy as np
 import pandas as pd

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -48,14 +48,14 @@ def _make_counts_summary(column, key, mapper, datatype="all"):
     binary = mapper.transform(column)
     s = binary.sum()
 
-    summary_data = np.array([s.index, s/s.sum()]).T
+    summary_data = np.array([s.index, s / s.sum()]).T
     summary = pd.DataFrame(summary_data, columns=[key, "counts"])
     summary["type"] = [datatype for _ in range(len(summary.index))]
 
     return summary
 
 
-def plot_fractions(column, idx, key, mapper, ax = None):
+def plot_fractions(column, idx, key, mapper, ax=None):
     """
     Plot the fractions
 
@@ -87,8 +87,9 @@ def plot_fractions(column, idx, key, mapper, ax = None):
     full_summary = _make_counts_summary(column, key, mapper, datatype="all")
 
     # compute the summary of the selected participants
-    selected_summary = _make_counts_summary(column[idx], key, mapper,
-                                            datatype="selected")
+    selected_summary = _make_counts_summary(
+        column[idx], key, mapper, datatype="selected"
+    )
 
     # concatenate the two DataFrames
     summary = pd.concat([full_summary, selected_summary])
@@ -101,19 +102,20 @@ def plot_fractions(column, idx, key, mapper, ax = None):
 
     # make figure
     if ax is None:
-        fig, ax = plt.subplots(1,1, figsize=(4*unique_labels, 8))
+        fig, ax = plt.subplots(1, 1, figsize=(4 * unique_labels, 8))
 
     sns.barplot(x=key, y="counts", hue="type", data=summary, ax=ax)
     ax.set_ylabel("Fraction of sample")
 
     xticklabels = [x.get_text() for x in ax.get_xticklabels()]
-    xtick_new = [x.split("_")[1] if len(x.split("_"))>1 else x for x in xticklabels]
+    xtick_new = [x.split("_")[1] if len(x.split("_")) > 1 else x for x in xticklabels]
     ax.set_xticklabels(xtick_new)
 
     # add targets
-    for i,l in enumerate(np.sort(list(mapper.targets.keys()))):
-        ax.hlines(mapper.targets[l], -0.5+i*1.0, 0.5+i*1.0, lw=2,
-                  linestyle="dashed")
+    for i, l in enumerate(np.sort(list(mapper.targets.keys()))):
+        ax.hlines(
+            mapper.targets[l], -0.5 + i * 1.0, 0.5 + i * 1.0, lw=2, linestyle="dashed"
+        )
 
     return ax, summary
 
@@ -149,16 +151,16 @@ def plot(df, idx, weights, mappers=None, cols=4):
     columns = list(mappers.keys())
     ncolumns = len(columns)
 
-    rows = np.floor(ncolumns/cols)
+    rows = np.floor(ncolumns / cols)
     if (ncolumns % cols) > 0:
         rows += 1
 
-    fig = plt.figure(figsize=(4*cols, 3*rows))
+    fig = plt.figure(figsize=(4 * cols, 3 * rows))
 
     axes = []
 
-    for i,c in enumerate(columns):
-        ax = fig.add_subplot(rows, cols, i+1)
+    for i, c in enumerate(columns):
+        ax = fig.add_subplot(rows, cols, i + 1)
         ax, _ = plot_fractions(df[c], idx, c, mappers[c], ax=ax)
         axes.append(ax)
 
@@ -227,27 +229,36 @@ def _plot_categorical(df, xlabel, ylabel, x_keys, y_keys, prefac, ax, cmap, s):
     tuples, counts = [], []
     for i in range(len(x_keys)):
         for j in range(len(y_keys)):
-            tuples.append((i,j))
+            tuples.append((i, j))
 
-            counts.append(len(df[(df[xlabel] == x_keys[i]) &
-                                 (df[ylabel] == y_keys[j])]))
+            counts.append(
+                len(df[(df[xlabel] == x_keys[i]) & (df[ylabel] == y_keys[j])])
+            )
 
     x, y = list(zip(*tuples))
 
     cmap = plt.cm.get_cmap(cmap)
-    sizes = (np.array(counts)/np.sum(counts))
+    sizes = np.array(counts) / np.sum(counts)
 
-    ax.scatter(x, y, s=s*1000*sizes, marker='o', linewidths=1, edgecolor='black',
-                c=cmap(prefac*sizes/(np.max(sizes)-np.min(sizes))), alpha=0.7)
+    ax.scatter(
+        x,
+        y,
+        s=s * 1000 * sizes,
+        marker="o",
+        linewidths=1,
+        edgecolor="black",
+        c=cmap(prefac * sizes / (np.max(sizes) - np.min(sizes))),
+        alpha=0.7,
+    )
 
     ax.set_xticks(np.arange(len(x_keys)))
     ax.set_xticklabels(x_keys)
-    ax.set_xlim(np.min(x)-1, np.max(x)+1)
+    ax.set_xlim(np.min(x) - 1, np.max(x) + 1)
     ax.set_xlabel(xlabel)
 
     ax.set_yticks(np.arange(len(y_keys)))
     ax.set_yticklabels(y_keys)
-    ax.set_ylim(np.min(y)-1, np.max(y)+1)
+    ax.set_ylim(np.min(y) - 1, np.max(y) + 1)
     ax.set_ylabel(ylabel)
 
     return ax
@@ -256,12 +267,15 @@ def _plot_categorical(df, xlabel, ylabel, x_keys, y_keys, prefac, ax, cmap, s):
 def _convert_continuous_to_categorical(column, mapper):
     binary = mapper.transform(column)
     b_stacked = binary.stack()
-    cat_column = pd.Series(pd.Categorical(b_stacked[b_stacked != 0].index.get_level_values(1)))
+    cat_column = pd.Series(
+        pd.Categorical(b_stacked[b_stacked != 0].index.get_level_values(1))
+    )
     return cat_column
 
 
-def _plot_categorical_and_continuous(df, xlabel, ylabel, x_keys, y_keys, ax,
-                                     cmap, n_cat=5, plottype="box"):
+def _plot_categorical_and_continuous(
+    df, xlabel, ylabel, x_keys, y_keys, ax, cmap, n_cat=5, plottype="box"
+):
     """
     Plot a categorical variable and a continuous variable against each
     other. Types of plots include box plot, violin plot, strip plot and swarm
@@ -305,25 +319,30 @@ def _plot_categorical_and_continuous(df, xlabel, ylabel, x_keys, y_keys, ax,
 
     current_palette = sns.color_palette(cmap, n_cat)
     if plottype == "box":
-        sns.boxplot(x=xlabel, y=ylabel, data=df, order=keys,
-                    palette=current_palette, ax=ax)
+        sns.boxplot(
+            x=xlabel, y=ylabel, data=df, order=keys, palette=current_palette, ax=ax
+        )
     elif plottype == "strip":
-        sns.stripplot(x=xlabel, y=ylabel, data=df, order=keys,
-                      palette=current_palette, ax=ax)
+        sns.stripplot(
+            x=xlabel, y=ylabel, data=df, order=keys, palette=current_palette, ax=ax
+        )
     elif plottype == "swarm":
-        sns.swarmplot(x=xlabel, y=ylabel, data=df, order=keys,
-                      palette=current_palette, ax=ax)
+        sns.swarmplot(
+            x=xlabel, y=ylabel, data=df, order=keys, palette=current_palette, ax=ax
+        )
     elif plottype == "violin":
-        sns.violinplot(x=xlabel, y=ylabel, data=df, order=keys,
-                       palette=current_palette, ax=ax)
+        sns.violinplot(
+            x=xlabel, y=ylabel, data=df, order=keys, palette=current_palette, ax=ax
+        )
     else:
         raise Exception("plottype not recognized!")
 
     return ax
 
 
-def _plot_continuous(df, xlabel, ylabel, ax, plottype="kde", n_levels=10,
-                     cmap="YlGnBu", shade=True):
+def _plot_continuous(
+    df, xlabel, ylabel, ax, plottype="kde", n_levels=10, cmap="YlGnBu", shade=True
+):
 
     """
     Plot a two continuous variables against each other in a scatter plot or a
@@ -365,29 +384,37 @@ def _plot_continuous(df, xlabel, ylabel, ax, plottype="kde", n_levels=10,
 
     """
 
-
     xcolumn = df[xlabel]
     ycolumn = df[ylabel]
     x_clean = xcolumn[np.isfinite(xcolumn) & np.isfinite(ycolumn)]
     y_clean = ycolumn[np.isfinite(ycolumn) & np.isfinite(xcolumn)]
 
     if plottype == "kde":
-        sns.kdeplot(x_clean, y_clean, n_levels=n_levels, shade=shade,
-                    ax=ax, cmap=cmap)
+        sns.kdeplot(x_clean, y_clean, n_levels=n_levels, shade=shade, ax=ax, cmap=cmap)
 
     elif plottype == "scatter":
         current_palette = sns.color_palette(cmap, 5)
         c = current_palette[2]
-        ax.scatter(x_clean, y_clean, color=c, s=10, lw=0,
-                   edgecolor="none", alpha=0.8)
+        ax.scatter(x_clean, y_clean, color=c, s=10, lw=0, edgecolor="none", alpha=0.8)
 
     return ax
 
 
-def plot_correlation(df, xlabel, ylabel, xmapper=None, ymapper=None,
-                      ax = None, xtype="categorical", ytype="categorical",
-                      cmap="YlGnBu", prefac=10., cat_type="box",
-                      cont_type="kde", s=2):
+def plot_correlation(
+    df,
+    xlabel,
+    ylabel,
+    xmapper=None,
+    ymapper=None,
+    ax=None,
+    xtype="categorical",
+    ytype="categorical",
+    cmap="YlGnBu",
+    prefac=10.0,
+    cat_type="box",
+    cont_type="kde",
+    s=2,
+):
 
     """
     Plot two variables against each other. Produces different types of
@@ -445,7 +472,7 @@ def plot_correlation(df, xlabel, ylabel, xmapper=None, ymapper=None,
 
     """
     if ax is None:
-        fig, ax = plt.subplots(1,1, figsize=(9,7))
+        fig, ax = plt.subplots(1, 1, figsize=(9, 7))
 
     if xtype == "categorical":
         if xmapper is None:
@@ -475,52 +502,80 @@ def plot_correlation(df, xlabel, ylabel, xmapper=None, ymapper=None,
         y_keys = ylabel
 
     if (xtype == "categorical") & (ytype == "categorical"):
-        ax = _plot_categorical(df, xlabel, ylabel,
-                               x_keys, y_keys, prefac,
-                               ax, cmap, s)
+        ax = _plot_categorical(df, xlabel, ylabel, x_keys, y_keys, prefac, ax, cmap, s)
 
-    elif ((xtype == "categorical") & (ytype == "continuous")):
+    elif (xtype == "categorical") & (ytype == "continuous"):
         n_cat = x_fields
         if cat_type == "categorical":
-            cat_column = _convert_continuous_to_categorical(df[ylabel],
-                                                            ymapper)
+            cat_column = _convert_continuous_to_categorical(df[ylabel], ymapper)
             cat_column.name = ylabel
             y_fields = len(ymapper.targets)
             y_keys = np.sort(list(ymapper.targets.keys()))
             df_temp = pd.DataFrame([df[xlabel], cat_column]).transpose()
 
-            ax = _plot_categorical(df_temp, xlabel, ylabel,
-                                   x_keys, y_keys, prefac,
-                                   ax, cmap)
+            ax = _plot_categorical(
+                df_temp, xlabel, ylabel, x_keys, y_keys, prefac, ax, cmap
+            )
         else:
-            ax = _plot_categorical_and_continuous(df, xlabel, ylabel, x_keys,
-                                                  y_keys, ax, cmap, n_cat=n_cat,
-                                                  plottype=cat_type)
+            ax = _plot_categorical_and_continuous(
+                df,
+                xlabel,
+                ylabel,
+                x_keys,
+                y_keys,
+                ax,
+                cmap,
+                n_cat=n_cat,
+                plottype=cat_type,
+            )
 
-    elif ((xtype == "continuous") & (ytype == "categorical")):
+    elif (xtype == "continuous") & (ytype == "categorical"):
         n_cat = y_fields
 
         if cat_type == "categorical":
-            cat_column = _convert_continuous_to_categorical(df[xlabel],
-                                                            xmapper)
+            cat_column = _convert_continuous_to_categorical(df[xlabel], xmapper)
             x_fields = len(xmapper.targets)
             x_keys = np.sort(list(xmapper.targets.keys()))
 
-            df_temp = pd.DataFrame([cat_column, df[ylabel]],
-                                   columns=[xlabel, ylabel])
+            df_temp = pd.DataFrame([cat_column, df[ylabel]], columns=[xlabel, ylabel])
 
-            ax = _plot_categorical(df_temp, xlabel, ylabel, x_fields, y_fields,
-                                   x_keys, y_keys, prefac, ax, cmap)
+            ax = _plot_categorical(
+                df_temp,
+                xlabel,
+                ylabel,
+                x_fields,
+                y_fields,
+                x_keys,
+                y_keys,
+                prefac,
+                ax,
+                cmap,
+            )
 
         else:
-            ax = _plot_categorical_and_continuous(df, xlabel, ylabel, x_keys,
-                                                  y_keys, ax, cmap,
-                                                  n_cat=n_cat,
-                                                  plottype=cat_type)
+            ax = _plot_categorical_and_continuous(
+                df,
+                xlabel,
+                ylabel,
+                x_keys,
+                y_keys,
+                ax,
+                cmap,
+                n_cat=n_cat,
+                plottype=cat_type,
+            )
 
-    elif ((xtype == "continuous") & (ytype == "continuous")):
-        ax = _plot_continuous(df, xlabel, ylabel, ax, plottype=cont_type,
-                              n_levels=10, cmap="YlGnBu", shade=True)
+    elif (xtype == "continuous") & (ytype == "continuous"):
+        ax = _plot_continuous(
+            df,
+            xlabel,
+            ylabel,
+            ax,
+            plottype=cont_type,
+            n_levels=10,
+            cmap="YlGnBu",
+            shade=True,
+        )
 
     else:
         raise Exception("Not currently supported!")
@@ -528,8 +583,9 @@ def plot_correlation(df, xlabel, ylabel, xmapper=None, ymapper=None,
     return ax
 
 
-def plot_distribution(df, xlabel, xmapper=None, xtype="categorical", ax=None,
-                      cmap="YlGnBu", bins=30):
+def plot_distribution(
+    df, xlabel, xmapper=None, xtype="categorical", ax=None, cmap="YlGnBu", bins=30
+):
     """
     Plot the distribution of a single variable in the DataFrame.
 
@@ -575,30 +631,44 @@ def plot_distribution(df, xlabel, xmapper=None, xtype="categorical", ax=None,
     c = sns.color_palette(cmap, 5)[2]
 
     if ax is None:
-        fig, ax = plt.subplots(1,1, figsize=(8,6))
+        fig, ax = plt.subplots(1, 1, figsize=(8, 6))
     if xtype == "categorical":
-        summary = _make_counts_summary(df[xlabel], xlabel,
-                                       xmapper, datatype="all")
+        summary = _make_counts_summary(df[xlabel], xlabel, xmapper, datatype="all")
 
         summary = summary.sort_values(by=xlabel)
 
-        #make figure
+        # make figure
         sns.barplot(x=xlabel, y="counts", data=summary, ax=ax, color=c)
         ax.set_ylabel("Fraction of sample")
 
     elif xtype == "continuous":
         column = df[xlabel]
         c_clean = column[np.isfinite(column)]
-        sns.distplot(c_clean, bins=bins, hist={"histtype": "stepfilled"},
-                    color=c, kde=True, ax=ax)
+        sns.distplot(
+            c_clean,
+            bins=bins,
+            hist={"histtype": "stepfilled"},
+            color=c,
+            kde=True,
+            ax=ax,
+        )
         ax.set_xlabel(xlabel)
         plt.ylabel("Number of occurrences")
 
     return ax
 
 
-def plot_triangle(df, weights, mappers=None, cmap="YlGnBu", bins=30,
-                  prefac=10., cat_type="box", cont_type="hist", fig=None):
+def plot_triangle(
+    df,
+    weights,
+    mappers=None,
+    cmap="YlGnBu",
+    bins=30,
+    prefac=10.0,
+    cat_type="box",
+    cont_type="hist",
+    fig=None,
+):
     """
     Make a triangle plot of all the relevant columns in the DataFrame.
 
@@ -667,7 +737,7 @@ def plot_triangle(df, weights, mappers=None, cmap="YlGnBu", bins=30,
 
     # construct the figure
     if fig is None:
-        fig, axes = plt.subplots(nkeys, nkeys, figsize=(4*nkeys, 3*nkeys))
+        fig, axes = plt.subplots(nkeys, nkeys, figsize=(4 * nkeys, 3 * nkeys))
 
     else:
         axes = []
@@ -686,40 +756,54 @@ def plot_triangle(df, weights, mappers=None, cmap="YlGnBu", bins=30,
 
             # upper triangle: print white space
             if i < j:
-                axes[i,j].spines['right'].set_visible(False)
-                axes[i,j].spines['top'].set_visible(False)
-                axes[i,j].spines['left'].set_visible(False)
-                axes[i,j].spines['bottom'].set_visible(False)
-                axes[i,j].set_facecolor('white')
-                axes[i,j].set_xlabel("")
-                axes[i,j].set_ylabel("")
-                axes[i,j].axis('off')
+                axes[i, j].spines["right"].set_visible(False)
+                axes[i, j].spines["top"].set_visible(False)
+                axes[i, j].spines["left"].set_visible(False)
+                axes[i, j].spines["bottom"].set_visible(False)
+                axes[i, j].set_facecolor("white")
+                axes[i, j].set_xlabel("")
+                axes[i, j].set_ylabel("")
+                axes[i, j].axis("off")
                 continue
 
             # diagonal: plot the univariate distribution
             elif i == j:
-                axes[i,j] = plot_distribution(df, kx, xmapper=mappers[kx],
-                                              xtype=xtype, ax=axes[i,j],
-                                              cmap=cmap, bins=bins)
+                axes[i, j] = plot_distribution(
+                    df,
+                    kx,
+                    xmapper=mappers[kx],
+                    xtype=xtype,
+                    ax=axes[i, j],
+                    cmap=cmap,
+                    bins=bins,
+                )
 
             # upper triangle: plot the bivariate distributions
             else:
-                axes[i,j] = plot_correlation(df, ky, kx, xmapper=mappers[ky],
-                                             ymapper=mappers[kx], ax=axes[i,j],
-                                             cmap=cmap, xtype=ytype,
-                                             ytype=xtype, prefac=prefac,
-                                             cat_type=cat_type,
-                                             cont_type=cont_type)
+                axes[i, j] = plot_correlation(
+                    df,
+                    ky,
+                    kx,
+                    xmapper=mappers[ky],
+                    ymapper=mappers[kx],
+                    ax=axes[i, j],
+                    cmap=cmap,
+                    xtype=ytype,
+                    ytype=xtype,
+                    prefac=prefac,
+                    cat_type=cat_type,
+                    cont_type=cont_type,
+                )
             if i < nkeys - 1:
-                axes[i,j].set_xticklabels([])
-                axes[i,j].set_xlabel("")
+                axes[i, j].set_xticklabels([])
+                axes[i, j].set_xlabel("")
             else:
-                [l.set_rotation(45) for l in axes[i,j].get_xticklabels()]
+                [l.set_rotation(45) for l in axes[i, j].get_xticklabels()]
 
             if j > 0:
-                axes[i,j].set_yticklabels([])
+                axes[i, j].set_yticklabels([])
                 if i != j:
-                    axes[i,j].set_ylabel("")
+                    axes[i, j].set_ylabel("")
 
     plt.tight_layout()
 

--- a/entrofy/utils.py
+++ b/entrofy/utils.py
@@ -5,6 +5,7 @@
 import numbers
 import numpy as np
 
+
 # The following is borrowed from scikit-learn v0.17
 def check_random_state(seed):
     """Turn seed into a np.random.RandomState instance
@@ -20,5 +21,6 @@ def check_random_state(seed):
     if isinstance(seed, np.random.RandomState):
         return seed
     raise ValueError(
-        "%r cannot be used to seed a numpy.random.RandomState" " instance" % seed
+        "%r cannot be used to seed a numpy.random.RandomState"
+        " instance" % seed
     )

--- a/entrofy/utils.py
+++ b/entrofy/utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
-'''Utilities for entrofy'''
+"""Utilities for entrofy"""
 
 import numbers
 import numpy as np
@@ -19,6 +19,6 @@ def check_random_state(seed):
         return np.random.RandomState(seed)
     if isinstance(seed, np.random.RandomState):
         return seed
-    raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
-                     ' instance' % seed)
-
+    raise ValueError(
+        "%r cannot be used to seed a numpy.random.RandomState" " instance" % seed
+    )

--- a/entrofy/version.py
+++ b/entrofy/version.py
@@ -2,5 +2,5 @@
 # -*- coding: utf-8 -*-
 """Version info"""
 
-short_version = '0.0'
-version = '0.0.0'
+short_version = "0.0"
+version = "0.0.0"

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,16 @@ from setuptools import setup, find_packages
 
 import imp
 
-version = imp.load_source('entrofy.version', 'entrofy/version.py')
+version = imp.load_source("entrofy.version", "entrofy/version.py")
 
 setup(
-    name='entrofy',
+    name="entrofy",
     version=version.version,
-    description='Entrofy',
-    author='Daniela Huppenkothen',
-    author_email='daniela.huppenkothen@nyu.edu',
-    url='http://github.com/dhuppenkothen/entrofy',
-    download_url='http://github.com/dhuppenkothen/entrofy/releases',
+    description="Entrofy",
+    author="Daniela Huppenkothen",
+    author_email="daniela.huppenkothen@nyu.edu",
+    url="http://github.com/dhuppenkothen/entrofy",
+    download_url="http://github.com/dhuppenkothen/entrofy/releases",
     packages=find_packages(),
     long_description="""Entrofy""",
     classifiers=[
@@ -25,14 +25,13 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
     ],
-    license='ISC',
+    license="ISC",
     install_requires=[
-        'pandas>=0.18',
-        'numpy>=1.10',
-        'seaborn>=0.6.0',
-        'matplotlib>=1.4.3'
+        "pandas>=0.18",
+        "numpy>=1.10",
+        "seaborn>=0.6.0",
+        "matplotlib>=1.4.3",
+        "future",
     ],
-    extras_require={
-        'docs': ['numpydoc']
-    }
+    extras_require={"docs": ["numpydoc"]},
 )


### PR DESCRIPTION
## Python 3 compatibility
I used the [`python-future` package](http://python-future.org/index.html) to inspect all of the `.py` files in the project and apply auto-fixes that make the code more compatible with Python 3. `python-future` also automatically makes the changes needed to keep Python 2.x compatibility. For example, the following is added to ensure division operations function as expected:

```python
from __future__ import division
```

Keeping Python 2 support also necessitates adding the `future` package as a dependency for `entrofy`.

## Black formatting
This PR also uses the popular [Black code formatter](https://black.readthedocs.io/) to impose consistent formatting to all of the Python modules.